### PR TITLE
Add channel whitelist functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The project requires the following environment variables:
 - `DISCORD_TOKEN`: Your Discord bot token.
 - `TEMPLATE_DIR`: The directory where your Tera templates are located. Defaults to `templates`.
 - `RATE_LIMIT_CONFIG`: The path to your rate limit configuration file. Defaults to `rate_limits.toml`.
+- `WHITELIST_CHANNELS`: A comma separated list of channel IDs that the bot is allowed to respond in. If not set, the bot will respond in all channels.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The project requires the following environment variables:
 - `DISCORD_TOKEN`: Your Discord bot token.
 - `TEMPLATE_DIR`: The directory where your Tera templates are located. Defaults to `templates`.
 - `RATE_LIMIT_CONFIG`: The path to your rate limit configuration file. Defaults to `rate_limits.toml`.
-- `WHITELIST_CHANNELS`: A comma separated list of channel IDs that the bot is allowed to respond in. If not set, the bot will respond in all channels.
+- `DATABASE_URL`: The URL to your database. For example `mysql://user:password@localhost/database`.
+- `WHITELIST_CHANNEL`: A comma separated list of channel IDs that the bot is allowed to respond in. If not set, the bot will respond in all channels.
 
 
 ## License

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -79,15 +79,14 @@ impl From<&poise::serenity_prelude::User> for UserContext {
 }
 
 pub async fn handle_completion(ctx: &poise::serenity_prelude::Context, app: &AppState, new_message: &Message) -> Result<()> {
-
 	// if whitelist is empty, assume user did not configure one
-	if !app.whitelist.is_empty() {
-		if !app.whitelist.contains(&new_message.channel_id) {
-			new_message.reply(ctx, "This channel is not whitelisted.").await
-					.into_diagnostic()
-					.wrap_err("failed to send whitelist message")?;
-			return Ok(());
-		}
+	if !app.whitelist.is_empty() && !app.whitelist.contains(&new_message.channel_id) {
+		new_message
+			.reply(ctx, "This channel is not whitelisted.")
+			.await
+			.into_diagnostic()
+			.wrap_err("failed to send whitelist message")?;
+		return Ok(());
 	}
 
 	if !check_rate_limit(new_message, app).await? {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -79,6 +79,17 @@ impl From<&poise::serenity_prelude::User> for UserContext {
 }
 
 pub async fn handle_completion(ctx: &poise::serenity_prelude::Context, app: &AppState, new_message: &Message) -> Result<()> {
+
+	// if whitelist is empty, assume user did not configure one
+	if !app.whitelist.is_empty() {
+		if !app.whitelist.contains(&new_message.channel_id) {
+			new_message.reply(ctx, "This channel is not whitelisted.").await
+					.into_diagnostic()
+					.wrap_err("failed to send whitelist message")?;
+			return Ok(());
+		}
+	}
+
 	if !check_rate_limit(new_message, app).await? {
 		// prevent user from spamming us with timeout
 		let error_report_future = tokio::time::timeout(std::time::Duration::from_secs(10), async {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,10 @@ mod gcra;
 mod invocation_builder;
 mod rate_limit_config;
 
-use std::str::FromStr;
-use std::time::Duration;
+use std::{
+	str::FromStr,
+	time::Duration,
+};
 
 use async_openai::{
 	config::OpenAIConfig,
@@ -25,6 +27,7 @@ use migration::{
 };
 use poise::{
 	serenity_prelude::{
+		ChannelId,
 		ClientBuilder,
 		CreateAllowedMentions,
 		FullEvent,
@@ -34,7 +37,6 @@ use poise::{
 	FrameworkError,
 	FrameworkOptions,
 };
-use poise::serenity_prelude::ChannelId;
 use sea_orm::{
 	ConnectOptions,
 	Database,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,10 @@ impl FromStr for ChannelWhiteList {
 	type Err = Report;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		if s.is_empty() {
+			return Ok(ChannelWhiteList(Vec::new()));
+		}
+
 		s.split(',')
 			.map(|s| s.parse().into_diagnostic().wrap_err("failed to parse channel id"))
 			.collect::<Result<Vec<_>, _>>()


### PR DESCRIPTION
Implemented a new feature that allows the bot to respond only in whitelisted channels. The whitelist setting can be set using the `WHITELIST_CHANNELS` environment variable.