### PR TITLE
🐛 Include ca-certificates in image

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ resolver = "2"
 entity = { path = "entity" }
 migration = { path = "migration" }
 
-async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 miette = { version = "7.0", features = ["fancy"] }
@@ -28,15 +27,14 @@ rand = "0.9"
 humantime = "2.1"
 log = "0.4"
 
-llm = { version = "1.3", features = ["openai"] }
+llm = { version = "1.3", features = ["openai", "rustls-tls"] }
 rmcp = { version = "0.6.0", features = [
     "client",
-    "transport-sse-client",
     "transport-sse-client-reqwest",
     "transport-streamable-http-client-reqwest",
     "transport-streamable-http-client",
     "transport-child-process"] }
-reqwest = "0.12"
+reqwest = { version = "0.12", features = ["rustls-tls"] }
 
 [package]
 name = "cheapt"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ COPY . .
 RUN cargo build --release --bin cheapt
 
 FROM ubuntu:latest AS runtime
+
+# install ca-certificates, used by reqwest for tls connections
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var
+
 ENV RUST_LOG="info,tracing::span=warn,serenity=warn"
 COPY --from=builder /app/target/release/cheapt /usr/bin/cheapt
 WORKDIR /


### PR DESCRIPTION
Install `ca-certificates` in the runtime image, which is required by current reqwest configuration.